### PR TITLE
DataHolder should honor domain of the callback function.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -29,7 +29,8 @@
 
     "globals": {
         "define": true,
-        "require": true
+        "require": true,
+        "afterEach": true
     },
 
     "node" : true,
@@ -59,7 +60,7 @@
     "latedef": true,
     "unused": "vars",
     "strict": false,
-    
+
     /* Relaxing options: */
     "eqnull": true
 }

--- a/AsyncValue.js
+++ b/AsyncValue.js
@@ -200,6 +200,10 @@ AsyncValue.prototype = {
             return callback.call(scope || this._scope || this, this.error, this.data);
         }
 
+        if (process.domain) {
+            callback = process.domain.bind(callback);
+        }
+
         addCallback(this, callback, scope);
 
         // only invoke loader if we have loader and we are not currently loading value

--- a/test/domain-tests.js
+++ b/test/domain-tests.js
@@ -1,0 +1,93 @@
+'use strict';
+
+require('chai').should();
+require('chai').Assertion.includeStack = true;
+var expect = require('chai').expect;
+var Domain = require('domain');
+
+var DataHolder = require('../DataHolder');
+
+function createGroupDone(limit, next) {
+
+    return function done(err) {
+        if (err) {
+            return next(err);
+        }
+        if (--limit <= 0) {
+            next();
+        }
+    };
+}
+
+describe.only('raptor-async/DataHolder domain' , function() {
+
+    afterEach(function () {
+        var current;
+        while((current = process.domain)) {
+            current.exit();
+        }
+    });
+
+    it('should preserve empty domain', function(done) {
+
+        var holder = new DataHolder();
+        holder.done(function shouldBeEmpty() {
+            expect(!!process.domain).equal(false);
+            done();
+        });
+
+        holder.resolve('ok');
+    });
+
+    it('should preserve corresponding state of domain', function(done) {
+
+        done = createGroupDone(2, done);
+
+        var holder = new DataHolder();
+        holder.done(function shouldBeEmpty() {
+            expect(!!process.domain).equal(false);
+            done();
+        });
+
+        var domain = Domain.create();
+        domain.run(function () {
+            holder.done(function shouldNoBeEmpty() {
+                expect(!!process.domain).equal(true);
+                done();
+            });
+        });
+
+        holder.resolve('ok');
+    });
+
+    it('should preserve corresponding state of domain, complex', function(done) {
+
+        done = createGroupDone(3, done);
+
+        var holder = new DataHolder();
+        holder.done(function shouldBeEmpty() {
+            expect(!!process.domain).equal(false);
+            done();
+        });
+
+        var domain1 = Domain.create();
+        domain1.run(function () {
+            holder.done(function shouldNoBeEmpty() {
+                expect(process.domain).to.equal(domain1);
+                done();
+            });
+        });
+
+        var domain2 = Domain.create();
+        domain2.run(function () {
+            holder.done(function shouldNoBeEmpty() {
+                expect(process.domain).to.equal(domain2);
+                done();
+            });
+        });
+
+        holder.resolve('ok');
+    });
+
+
+});


### PR DESCRIPTION
Currently, due to caching of a callback function in done() till the
result becomes cached the first caller that initiates the building of
the cache entry will overwrite domains of all other callers that are
waiting for it to complete in the callback queue.
